### PR TITLE
feat: enable npx support and automated npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,27 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  npm-publish:
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Publish to NPM
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Game Encyclopedia MCP Server
+# Videogame Encyclopedia MCP Server
 
 A Model Context Protocol (MCP) server that provides structured video game information from Steam and SteamGridDB. This server exposes tools for searching games and retrieving comprehensive metadata including descriptions, categories, release dates, player counts, and visual assets like logos, boxart, and icons.
 
@@ -99,13 +99,16 @@ npx -y @smithery/cli@latest install videogame-encyclopedia-mcp-server --client c
 #### Via uvx
 If you have `uv` installed, you can run the server directly (requires Node.js locally):
 ```bash
-uvx --from node game-encyclopedia-mcp
+uvx --from node videogame-encyclopedia-mcp-server
 ```
 
 #### Via npx
 ```bash
 npx videogame-encyclopedia-mcp-server
 ```
+
+> [!NOTE]
+> To publish this package to NPM, you must set an `NPM_TOKEN` secret in your GitHub repository settings.
 
 ## Available Tools
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "game-encyclopedia-mcp-server",
+  "name": "videogame-encyclopedia-mcp-server",
   "version": "1.0.0",
   "description": "MCP server providing structured video game information from Steam and SteamGridDB",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "game-encyclopedia-mcp": "dist/index.js"
+    "videogame-encyclopedia-mcp-server": "dist/index.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Description
This PR enables `npx` support and introduces automated NPM publishing to the release pipeline.

### Changes
- **Package Renaming**: Renamed the package to `videogame-encyclopedia-mcp-server` to match the GitHub repository name and provide a consistent `npx` experience.
- **Binary Renaming**: Simplified the binary name to `videogame-encyclopedia-mcp-server` for seamless `npx` usage.
- **Automated NPM Publishing**: Added an `npm-publish` job to the `.github/workflows/release.yml` workflow. It will automatically publish the package to the NPM registry whenever a new GitHub release is created (triggered by tags `v*`).
- **Documentation**: Updated `README.md` with accurate `npx` instructions and a note about the required `NPM_TOKEN` secret.

### Verification Results
- Local build succeeds (`npm run build`).
- Package configuration verified for `npx`/`uvx` compatibility.

### Action Items for Maintainer
- Please add a secret named `NPM_TOKEN` to your GitHub repository settings with a valid NPM automation token to enable automated publishing.
