### PR TITLE
chore: reset version to 0.0.0 (managed by CI/CD)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "videogame-encyclopedia-mcp-server",
-  "version": "1.0.1",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "videogame-encyclopedia-mcp-server",
-      "version": "1.0.1",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videogame-encyclopedia-mcp-server",
-  "version": "1.0.1",
+  "version": "0.0.0",
   "description": "MCP server providing structured video game information from Steam and SteamGridDB",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Description
This PR resets the version in `package.json` and `package-lock.json` to `0.0.0`.

### Rationale
Since we use GitHub Actions to dynamically set the package version from Git tags during the release process, the version in the `main` branch doesn't need to be kept in sync manually. Setting it to `0.0.0` makes it clear that the version is managed by the automated CI/CD pipeline and prevents accidental local publishing with a stale version.
