### PR TITLE
feat: steam dlc explorer tool (steam_get_dlc_list)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A Model Context Protocol (MCP) server that provides structured video game inform
   - Release date
   - Pricing information
   - Developer and publisher details
+- **steam_get_dlc_list**: List all available DLCs for a specific game
 
 ### SteamGridDB Integration
 - **steamgrid_search_game**: Search for games on SteamGridDB
@@ -143,6 +144,20 @@ Search for games on Steam by name.
 ### 2. steam_get_details
 
 Get detailed information about a Steam game.
+
+**Input:**
+- `appid` (number, required): Steam App ID
+
+**Example:**
+```json
+{
+  "appid": 1245620
+}
+```
+
+### 3. steam_get_dlc_list
+
+Get a list of all available DLCs for a specific Steam game.
 
 **Input:**
 - `appid` (number, required): Steam App ID

--- a/scripts/scratch-test-batch.ts
+++ b/scripts/scratch-test-batch.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+async function testBatchAppDetails() {
+    const appids = [1245620, 1774580]; // Elden Ring and one of its DLCs
+    const url = `https://store.steampowered.com/api/appdetails?appids=${appids.join(',')}&filters=basic`;
+    console.log(`GET ${url}`);
+    const response = await axios.get(url);
+    console.log(JSON.stringify(response.data, null, 2));
+}
+
+testBatchAppDetails();

--- a/scripts/scratch-test-dlc-batch.ts
+++ b/scripts/scratch-test-dlc-batch.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+async function testDLCBatch() {
+    const dlcIds = [2778590, 2778580]; // Elden Ring DLC IDs from previous test
+    const url = `https://store.steampowered.com/api/appdetails?appids=${dlcIds.join(',')}&filters=basic`;
+    console.log(`GET ${url}`);
+    try {
+        const response = await axios.get(url);
+        console.log('Response state:', response.status);
+        console.log('Results:');
+        for (const id of dlcIds) {
+            console.log(`ID ${id}: success=${response.data[id]?.success}, name=${response.data[id]?.data?.name}`);
+        }
+    } catch (error: any) {
+        console.error('Batch failed:', error.message);
+    }
+}
+
+testDLCBatch();

--- a/scripts/scratch-test-dlc-full.ts
+++ b/scripts/scratch-test-dlc-full.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+async function testDLCListFull() {
+    const appid = 1245620; // Elden Ring
+    const url = `https://store.steampowered.com/api/appdetails?appids=${appid}`; // No filter
+    console.log(`GET ${url}`);
+    const response = await axios.get(url);
+    const data = response.data[appid].data;
+    console.log('DLC Data:', JSON.stringify(data.dlc, null, 2));
+}
+
+testDLCListFull();

--- a/scripts/scratch-test-dlc-ids.ts
+++ b/scripts/scratch-test-dlc-ids.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+async function testDLCList() {
+    const appid = 1245620; // Elden Ring
+    const url = `https://store.steampowered.com/api/appdetails?appids=${appid}&filters=basic`;
+    console.log(`GET ${url}`);
+    const response = await axios.get(url);
+    const data = response.data[appid].data;
+    console.log('DLC IDs:', data.dlc);
+}
+
+testDLCList();

--- a/scripts/test-steam-dlc.ts
+++ b/scripts/test-steam-dlc.ts
@@ -1,0 +1,40 @@
+import { getSteamDLCList } from '../src/tools/steam.js';
+
+async function testSteamDLC() {
+    console.log('Testing Steam DLC Explorer Tool (steam_get_dlc_list)...');
+
+    // Test 1: Elden Ring (has 2 DLCs)
+    try {
+        const appid = 1245620;
+        console.log(`\nFetching DLCs for Elden Ring (App ID: ${appid})...`);
+        const result = await getSteamDLCList({ appid });
+
+        console.log('Game Name:', result.name);
+        console.log('Total DLCs:', result.total_dlc_count);
+        console.log('Retrieved DLCs:', result.retrieved_count);
+
+        result.dlc.forEach((dlc: any) => {
+            console.log(`- [${dlc.appid}] ${dlc.name}`);
+        });
+
+        if (result.dlc.length > 0) {
+            console.log('\nSuccess! DLCs retrieved correctly.');
+        } else {
+            console.log('\nNo DLCs found (as expected if game has none).');
+        }
+    } catch (error: any) {
+        console.error('DLC list tool failed:', error.message);
+    }
+
+    // Test 2: A game with no DLC (e.g., a simple tool or indie game)
+    try {
+        const appid = 400; // Portal
+        console.log(`\nFetching DLCs for Portal (App ID: ${appid})...`);
+        const result = await getSteamDLCList({ appid });
+        console.log('Total DLCs:', result.total_dlc_count);
+    } catch (error: any) {
+        console.error('Portal test failed:', error.message);
+    }
+}
+
+testSteamDLC();

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
     ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { loadConfig } from './config.js';
-import { searchSteamGames, getSteamGameDetails } from './tools/steam.js';
+import { searchSteamGames, getSteamGameDetails, getSteamDLCList } from './tools/steam.js';
 import { searchSteamGridGames, getSteamGridAssets } from './tools/steamgrid.js';
 import { getFullGameProfile } from './tools/unified.js';
 
@@ -113,6 +113,21 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 },
             },
             {
+                name: 'steam_get_dlc_list',
+                description:
+                    'Get a list of all available DLCs for a specific Steam game by its App ID. Returns the App ID and name for each DLC.',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        appid: {
+                            type: 'number',
+                            description: 'The Steam App ID of the main game',
+                        },
+                    },
+                    required: ['appid'],
+                },
+            },
+            {
                 name: 'game_get_full_profile',
                 description:
                     'Get a comprehensive game profile including metadata from Steam and visual assets (logo, hero, grid, icon) from SteamGridDB in a single request. This is the recommended tool for getting a complete overview of a game.',
@@ -151,6 +166,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
             case 'steam_get_details': {
                 const result = await getSteamGameDetails(args as any);
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(result, null, 2),
+                        },
+                    ],
+                };
+            }
+
+            case 'steam_get_dlc_list': {
+                const result = await getSteamDLCList(args as any);
                 return {
                     content: [
                         {

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,15 @@ export interface SteamGridAssetsInput {
     gameId: number;
     assetTypes?: ('grid' | 'hero' | 'logo' | 'icon')[];
 }
+
+export interface SteamDLCListInput {
+    appid: number;
+}
+
+export interface SteamDLC {
+    appid: number;
+    name: string;
+}
 // Unified Tool Types
 export interface UnifiedSearchInput {
     query: string;


### PR DESCRIPTION
## Description
This PR implements the `steam_get_dlc_list` tool (Issue #16).

### Features
- **Keyless Operation**: Uses public Steam Store APIs to retrieve DLC information without requiring an API key.
- **Detailed Output**: Returns the App ID and Name for each DLC.
- **Efficiency**: Limit to the first 10 DLC names to balance information and performance.

### Verification
Verified with `scripts/test-steam-dlc.ts`:
```bash
npx tsx scripts/test-steam-dlc.ts
```
