### PR TITLE
feat: steam live player count tool (steam_get_player_count)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A Model Context Protocol (MCP) server that provides structured video game inform
 - **steam_get_dlc_list**: List all available DLCs for a specific game
 - **steam_get_reviews_summary**: Get community ratings and top review snippets
 - **steam_get_game_news**: Get the latest news and announcements for a game
+- **steam_get_player_count**: Get the current number of online players for a game
 - **steam_get_top_sellers**: Get current global top selling games
 - **steam_get_top_games**: Browse top games by genre or category
 - **steam_get_genres**: Get a list of common Steam genres for discovery
@@ -204,7 +205,21 @@ Get the latest news and announcements for a specific Steam game.
 }
 ```
 
-### 6. steam_get_genres
+### 6. steam_get_player_count
+
+Get the current number of players online for a specific Steam game.
+
+**Input:**
+- `appid` (number, required): Steam App ID of the game
+
+**Example:**
+```json
+{
+  "appid": 1245620
+}
+```
+
+### 7. steam_get_genres
 
 Get a list of common Steam genres and categories for discovery.
 
@@ -213,7 +228,7 @@ Get a list of common Steam genres and categories for discovery.
 {}
 ```
 
-### 7. steam_get_top_sellers
+### 8. steam_get_top_sellers
 
 Get the current global top selling games on Steam.
 
@@ -227,7 +242,7 @@ Get the current global top selling games on Steam.
 }
 ```
 
-### 8. steam_get_top_games
+### 9. steam_get_top_games
 
 Browse top games for a specific Steam category or genre (e.g., "Action", "RPG", "Strategy").
 
@@ -243,7 +258,7 @@ Browse top games for a specific Steam category or genre (e.g., "Action", "RPG", 
 }
 ```
 
-### 9. steamgrid_search_game
+### 10. steamgrid_search_game
 
 Search for games on SteamGridDB.
 
@@ -257,7 +272,7 @@ Search for games on SteamGridDB.
 }
 ```
 
-### 10. steamgrid_get_assets
+### 11. steamgrid_get_assets
 
 Get visual assets for a game from SteamGridDB.
 
@@ -273,7 +288,7 @@ Get visual assets for a game from SteamGridDB.
 }
 ```
 
-### 11. game_get_full_profile
+### 12. game_get_full_profile
 
 Get a comprehensive game profile combining metadata from Steam and visual assets from SteamGridDB. This tool automatically handles the mapping between Steam and SteamGridDB.
 

--- a/scripts/test-steam-player-count.ts
+++ b/scripts/test-steam-player-count.ts
@@ -1,0 +1,34 @@
+import { getSteamPlayerCount } from '../src/tools/steam.js';
+
+async function testPlayerCount() {
+    console.log('Testing Steam Live Player Count Tool...');
+
+    // Test 1: Elden Ring (1245620)
+    try {
+        console.log('\nFetching player count for Elden Ring (1245620)...');
+        const result = await getSteamPlayerCount({ appid: 1245620 });
+        console.log(`Current Players online: ${result.player_count.toLocaleString()}`);
+    } catch (error: any) {
+        console.error('Elden Ring test failed:', error.message);
+    }
+
+    // Test 2: CS2 (730) - Always has high player count
+    try {
+        console.log('\nFetching player count for CS2 (730)...');
+        const result = await getSteamPlayerCount({ appid: 730 });
+        console.log(`Current Players online: ${result.player_count.toLocaleString()}`);
+    } catch (error: any) {
+        console.error('CS2 test failed:', error.message);
+    }
+
+    // Test 3: Invalid App ID
+    try {
+        console.log('\nFetching player count for Invalid App ID (999999999)...');
+        const result = await getSteamPlayerCount({ appid: 999999999 });
+        console.log(`Player count: ${result.player_count}`);
+    } catch (error: any) {
+        console.log('Expected error caught:', error.message);
+    }
+}
+
+testPlayerCount();

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
     ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { loadConfig } from './config.js';
-import { searchSteamGames, getSteamGameDetails, getSteamDLCList, getSteamReviewsSummary, getSteamTopSellers, getSteamTopGames, getSteamGenres, getSteamGameNews } from './tools/steam.js';
+import { searchSteamGames, getSteamGameDetails, getSteamDLCList, getSteamReviewsSummary, getSteamTopSellers, getSteamTopGames, getSteamGenres, getSteamGameNews, getSteamPlayerCount } from './tools/steam.js';
 import { searchSteamGridGames, getSteamGridAssets } from './tools/steamgrid.js';
 import { getFullGameProfile } from './tools/unified.js';
 
@@ -161,6 +161,20 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 },
             },
             {
+                name: 'steam_get_player_count',
+                description: 'Get the current number of players online for a specific Steam game.',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        appid: {
+                            type: 'number',
+                            description: 'Steam App ID of the game',
+                        },
+                    },
+                    required: ['appid'],
+                },
+            },
+            {
                 name: 'steam_get_genres',
                 description: 'Get a list of common Steam genres and categories for discovery.',
                 inputSchema: {
@@ -274,6 +288,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
             case 'steam_get_game_news': {
                 const result = await getSteamGameNews(args as any);
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(result, null, 2),
+                        },
+                    ],
+                };
+            }
+
+            case 'steam_get_player_count': {
+                const result = await getSteamPlayerCount(args as any);
                 return {
                     content: [
                         {

--- a/src/tools/steam.ts
+++ b/src/tools/steam.ts
@@ -13,6 +13,8 @@ import type {
     SteamNewsInput,
     SteamNewsResponse,
     SteamNewsItem,
+    SteamPlayerCountInput,
+    SteamPlayerCountResponse,
 } from '../types.js';
 import { Config } from '../config.js';
 
@@ -20,6 +22,7 @@ const STORE_SEARCH_URL = 'https://store.steampowered.com/api/storesearch/';
 const STEAM_APP_DETAILS_URL = 'https://store.steampowered.com/api/appdetails';
 const STEAM_REVIEWS_URL = 'https://store.steampowered.com/appreviews/';
 const STEAM_NEWS_URL = 'https://api.steampowered.com/ISteamNews/GetNewsForApp/v0002/';
+const STEAM_PLAYER_COUNT_URL = 'https://api.steampowered.com/ISteamUserStats/GetNumberOfCurrentPlayers/v1/';
 
 export async function searchSteamGames(input: SteamSearchInput) {
     const { query, limit = 10 } = input;
@@ -317,5 +320,29 @@ export async function getSteamGameNews(input: SteamNewsInput) {
         appid: appnews.appid,
         count: newsItems.length,
         news: newsItems
+    };
+}
+
+/**
+ * Get the current number of players online for a specific Steam game
+ */
+export async function getSteamPlayerCount(input: SteamPlayerCountInput) {
+    const { appid } = input;
+
+    const response = await axios.get<{ response: SteamPlayerCountResponse }>(STEAM_PLAYER_COUNT_URL, {
+        params: {
+            appid,
+        },
+    });
+
+    const data = response.data.response;
+
+    if (data.result !== 1) {
+        throw new Error(`Failed to retrieve player count for App ID ${appid}`);
+    }
+
+    return {
+        appid,
+        player_count: data.player_count,
     };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,15 @@ export interface SteamNewsResponse {
     newsitems: SteamNewsItem[];
     count: number;
 }
+
+export interface SteamPlayerCountInput {
+    appid: number;
+}
+
+export interface SteamPlayerCountResponse {
+    player_count: number;
+    result: number;
+}
 // Unified Tool Types
 export interface UnifiedSearchInput {
     query: string;


### PR DESCRIPTION
## Description
This PR implements the Steam Live Player Count feature (Issue #11).

### Features
- **New Tool**: `steam_get_player_count`
- **Functionality**: Retrieves the current number of players online for a specific Steam game.
- **Keyless Implementation**: Uses the official `ISteamUserStats/GetNumberOfCurrentPlayers` web API, which does not require an API key.

### Verification
Verified with `scripts/test-steam-player-count.ts`:
```bash
npx tsx scripts/test-steam-player-count.ts
```

Example output for Elden Ring (1245620):
```json
{
  "appid": 1245620,
  "player_count": 42608
}
```
